### PR TITLE
Fix env declaration.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,10 +11,11 @@
     name: local-registry
     ports: "5000:5000"
     volumes: "/var/lib/local-registry:/srv/registry"
-    env: "STANDALONE=false"
-    env: "MIRROR_SOURCE=https://registry-1.docker.io"
-    env: "MIRROR_SOURCE_INDEX=https://index.docker.io"
-    env: "STORAGE_PATH=/srv/registry"
+    env: 
+    - "STANDALONE=false"
+    - "MIRROR_SOURCE=https://registry-1.docker.io"
+    - "MIRROR_SOURCE_INDEX=https://index.docker.io"
+    - "STORAGE_PATH=/srv/registry"
 
 - name: Deploy systemd unit file
   copy:


### PR DESCRIPTION
Fix warining:
[WARNING]: While constructing a mapping from
[..]/.ansible/roles/gbraad.docker-registry/tasks/main.yml, line 10,
column 5, found a duplicate dict key (env). Using last defined value
only.